### PR TITLE
Fix tuwunel authentication loop causing high CPU usage

### DIFF
--- a/docs/TUWUNEL_AUTH_LOOP_FIX_SUMMARY.md
+++ b/docs/TUWUNEL_AUTH_LOOP_FIX_SUMMARY.md
@@ -1,0 +1,99 @@
+# Tuwunel Authentication Loop Fix - Implementation Summary
+
+## Problem Identified
+The matrix-client container was causing the tuwunel homeserver to consume 75-90% CPU continuously for 7+ days, impacting all services on the host including Jellyfin. 
+
+### Root Cause
+1. `periodic_agent_sync` ran every **0.5 seconds** (line 688 of `src/matrix/client.py`)
+2. Each sync iterated through all 56 agent rooms
+3. For each room, `auto_accept_invitations_with_tracking` logged in @admin and @letta users **even if they were already joined**
+4. This resulted in **~200 login requests per second** = **17,280,000 logins per day**
+
+## Implementation
+
+### Changes Made
+
+#### 1. Throttled Sync Interval (`src/matrix/client.py:688`)
+- Changed default interval from 0.5s to 60s (120x reduction)
+- Made interval configurable via `MATRIX_AGENT_SYNC_INTERVAL` environment variable
+- Added INFO-level logging when periodic sync starts
+
+#### 2. Matrix API Membership Verification (`src/core/room_manager.py:136`)
+- Added `check_user_in_room(room_id, user_id)` function
+- Uses Matrix API `/joined_members` endpoint to verify actual membership
+- Provides authoritative source of truth instead of relying on local cache/assumptions
+
+#### 3. Pre-Login Membership Check (`src/core/room_manager.py:481`)
+- Modified `auto_accept_invitations_with_tracking` to check Matrix API **before** attempting login
+- Only performs login/join if API confirms user is not already a member
+- Populates cache with API-verified membership state
+
+#### 4. Global Manager Singleton (`src/core/agent_user_manager.py:817`)
+- Created `_global_manager` module-level variable
+- `run_agent_sync` now reuses same `AgentUserManager` instance across periodic cycles
+- Preserves `RoomManager` cache between sync runs
+
+#### 5. Metrics and Observability (`src/core/agent_user_manager.py:387-594`)
+- Added sync metrics tracking: cache_hits, api_checks, login_attempts, rooms_processed
+- Log sync duration and metrics at completion
+- Structured logging for cache hits and API verification
+
+### File Modifications
+1. `src/matrix/client.py` - Sync interval configuration
+2. `src/core/room_manager.py` - API membership checks, cache management
+3. `src/core/agent_user_manager.py` - Global singleton, metrics tracking
+
+## Results
+
+### Before Fix
+- **Tuwunel CPU**: 75-90% sustained
+- **Login Rate**: ~200/second (17M+/day)
+- **Pattern**: @admin and @letta logging in every 1-2 seconds for 56 rooms
+
+### After Fix
+- **Tuwunel CPU**: 0.00% at idle, brief spikes during 60s sync cycles
+- **Login Rate**: 3 logins per 2 minutes (~2/minute vs 12,000/minute before)
+- **Pattern**: Logins only occur when membership verification fails or rooms are new
+
+### Performance Improvement
+- **99.9% reduction** in login traffic
+- **>90% reduction** in CPU usage
+- System resources freed for Jellyfin and other services
+
+## Configuration
+
+### Environment Variables
+```bash
+# Optional: Override sync interval (default: 60 seconds)
+MATRIX_AGENT_SYNC_INTERVAL=120
+```
+
+## Monitoring
+
+### Key Log Messages
+- `Starting periodic agent sync with interval: Xs` - Sync cadence
+- `Creating new AgentUserManager instance` - First sync after restart
+- `Reusing existing AgentUserManager instance (cache preserved)` - Subsequent syncs
+- `User X already in room Y (verified via API), updating cache` - API-prevented login
+- `Sync metrics - Cache hits: X, API checks: Y, Login attempts: Z` - Per-sync stats
+
+### Health Checks
+```bash
+# Check tuwunel CPU
+docker stats matrix-synapse-deployment-tuwunel-1 --no-stream
+
+# Count recent logins
+docker logs matrix-synapse-deployment-tuwunel-1 --since 5m | grep "logged in" | wc -l
+
+# View sync metrics
+docker logs matrix-synapse-deployment-matrix-client-1 --since 2m | grep "Sync metrics"
+```
+
+## Future Improvements
+1. Persist membership cache to disk for faster container restarts
+2. Add Prometheus metrics export for dashboarding
+3. Implement rate limiting at tuwunel API level as safety backstop
+4. Consider webhook-based membership updates instead of polling
+
+## Related Documents
+- [TUWUNEL_AUTH_LOOP_PRD.md](./TUWUNEL_AUTH_LOOP_PRD.md) - Original requirements document

--- a/docs/TUWUNEL_AUTH_LOOP_PRD.md
+++ b/docs/TUWUNEL_AUTH_LOOP_PRD.md
@@ -1,0 +1,61 @@
+# Tuwunel Authentication Loop PRD
+
+## Overview
+Persistent login attempts from the matrix-client container smother the tuwunel homeserver, starving Jellyfin and other services of CPU. The loop is caused by an aggressive periodic sync that reprocesses every agent-room mapping twice per second. Each iteration triggers redundant admin and @letta logins and joins across 56+ rooms, yielding tens of millions of login calls per day. This document defines the requirements to eliminate the loop while ensuring agent provisioning remains reliable.
+
+## Problem Statement
+- `periodic_agent_sync` in `src/matrix/client.py` runs every 0.5s and invokes `sync_agents_to_users`.
+- `sync_agents_to_users` iterates through all agent rooms and always calls `auto_accept_invitations_with_tracking`.
+- `auto_accept_invitations_with_tracking` re-authenticates @admin and @letta for every room regardless of membership, generating 100+ login requests per second.
+- Result: tuwunel container saturates CPU (>75% for 7+ days) and degrades host-level services including Jellyfin.
+
+## Goals
+1. Reduce login/join traffic to only when membership or invitations truly change.
+2. Maintain automatic provisioning for new agents, rooms, and admin presence.
+3. Ensure tuwunel CPU usage stays below 20% at idle with current agent counts.
+
+## Non-Goals
+- Replacing tuwunel with Synapse or other homeservers.
+- Altering agent onboarding flows outside of Matrix membership management.
+- Optimizing Jellyfin itself (it should simply benefit from released CPU headroom).
+
+## Functional Requirements
+1. **Throttled Sync Cadence**
+   - Default `periodic_agent_sync` interval must be configurable and increased to ≥60 seconds.
+   - Provide ability to override via environment variable for emergency debugging.
+2. **Reusable Manager Instance**
+   - `run_agent_sync` must reuse a singleton `AgentUserManager` (and thus `MatrixRoomManager`) to persist caches between cycles.
+   - Reload configuration only when environment variables change.
+3. **Membership Cache Backed by Matrix API**
+   - `MatrixRoomManager.auto_accept_invitations_with_tracking` must maintain an in-memory cache keyed by `(room_id, username)` and skip login/join requests when a user is already joined.
+   - Cache accuracy must be validated through Matrix API membership endpoints so the loop trusts authoritative homeserver state instead of local assumptions.
+   - Cache must invalidate when membership state is unknown or when an explicit recheck is requested.
+4. **Conditional Invitation Handling**
+   - Invitation acceptance should run only when `invitation_status` indicates "invited"/"unknown" or when Matrix API membership checks (e.g., `/joined_members`) report the user absent.
+   - Detect and remediate room drift without rejoining rooms already confirmed.
+5. **Monitoring Hooks**
+   - Emit structured logs when cache hits skip login attempts, and when throttled sync runs start/finish.
+   - Provide metrics counters (or log-derived counts) for login attempts per sync.
+
+## Non-Functional Requirements
+- Changes must not increase initial agent provisioning time by more than 10% (baseline = current full sync duration).
+- Solution must operate under network partitions without locking up the sync loop.
+- Memory overhead of caching should remain under 5 MB for 200 agents.
+
+## Risks & Mitigations
+1. **Stale Cache Causing Missed Invites**
+   - Add manual invalidation path when invitation status changes or when room membership events indicate leaves.
+2. **Longer Detection Time for New Agents**
+   - Provide manual trigger command (CLI or admin API) to run immediate sync when needed.
+3. **Singleton Lifecycle Issues**
+   - Ensure singleton manager resets on unrecoverable errors or container restart; guard with try/except.
+
+## Success Metrics
+- Login rate reduced from ~200/sec to <5/sec at steady state.
+- Tuwnuel container CPU usage drops below 20% outside sync bursts.
+- Sync logs show cache hit ratio >90% after initial cycle.
+
+## Open Questions
+1. Should we persist invitation/membership state on disk to survive container restarts?
+2. Do we need additional rate limiting on tuwunel API endpoints as a safety backstop?
+3. Is there a requirement to expose these metrics in Prometheus instead of logs?

--- a/src/matrix/client.py
+++ b/src/matrix/client.py
@@ -685,11 +685,17 @@ async def join_room_if_needed(client_instance, room_id_or_alias, logger: logging
         }, exc_info=True)
         return None
 
-async def periodic_agent_sync(config, logger, interval=0.5):  # Reduced to 0.5 seconds for faster agent detection
+async def periodic_agent_sync(config, logger, interval=None):
     """Periodically sync Letta agents to Matrix users via OpenAI endpoint"""
+    # Allow override via environment variable, default to 60 seconds
+    if interval is None:
+        interval = int(os.getenv("MATRIX_AGENT_SYNC_INTERVAL", "60"))
+    
+    logger.info(f"Starting periodic agent sync with interval: {interval}s")
+    
     while True:
         await asyncio.sleep(interval)
-        logger.debug("Running periodic agent sync via OpenAI endpoint...")  # Changed to debug to reduce log noise
+        logger.debug("Running periodic agent sync via OpenAI endpoint...")
         try:
             await run_agent_sync(config)
             logger.debug("Periodic agent sync completed successfully")


### PR DESCRIPTION
## Summary
Fixes the infinite authentication loop that caused tuwunel homeserver CPU to run at 75-90% continuously for 7+ days, impacting all host services including Jellyfin.

## Problem
- `periodic_agent_sync` ran every 0.5 seconds
- Each cycle logged in @admin and @letta for all 56 agent rooms, even if already joined
- Result: ~200 login requests per second (17M+ logins per day)

## Solution
1. **Throttled sync interval** from 0.5s to 60s (configurable via `MATRIX_AGENT_SYNC_INTERVAL`)
2. **Matrix API membership verification** using `/joined_members` endpoint before attempting login
3. **Global manager singleton** to preserve cache between sync cycles
4. **Metrics tracking** for observability (cache hits, API checks, login attempts)

## Results
- ✅ Tuwunel CPU: **0.00%** at idle (was 75-90%)
- ✅ Login rate: **~2/minute** (was ~200/second)
- ✅ **99.9% reduction** in login traffic
- ✅ System resources freed for other services

## Testing
Verified on production system:
- Container running for 2+ minutes with no issues
- Login count in last 3 minutes: 3 (vs thousands before)
- CPU usage stable at 0%

## Documentation
- PRD: `docs/TUWUNEL_AUTH_LOOP_PRD.md`
- Implementation summary: `docs/TUWUNEL_AUTH_LOOP_FIX_SUMMARY.md`

## Files Changed
- `src/matrix/client.py` - Sync interval configuration
- `src/core/room_manager.py` - API membership checks, cache management
- `src/core/agent_user_manager.py` - Global singleton, metrics tracking

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved persistent authentication loop in TUWUNEL system, significantly reducing excessive login and join requests.

* **Performance**
  * Optimized sync frequency and implemented membership caching for improved system efficiency.

* **Monitoring**
  * Enhanced observability with detailed metrics and logging for sync operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->