### PR TITLE
Fix SSRF vulnerability in agent_media outbound URL fetching (bd-lu93)

### DIFF
--- a/src/matrix/agent_media.py
+++ b/src/matrix/agent_media.py
@@ -6,6 +6,7 @@ import aiohttp
 
 from src.matrix.config import Config
 from src.matrix.agent_auth import get_agent_token as _get_agent_token
+from src.utils.ssrf_protection import SSRFError, validate_url
 
 
 _AGENT_UPLOAD_TIMEOUT = aiohttp.ClientTimeout(total=30)
@@ -110,6 +111,11 @@ async def fetch_and_send_image(
     logger: logging.Logger,
 ) -> Optional[str]:
     try:
+        try:
+            validate_url(image_url)
+        except SSRFError as e:
+            logger.warning("[IMAGE] SSRF blocked: %s — %s", image_url, e)
+            return None
         fetch_headers = {"User-Agent": "MatrixBridge/1.0"}
         async with aiohttp.ClientSession() as session:
             try:
@@ -298,6 +304,11 @@ async def fetch_and_send_file(
     logger: logging.Logger,
 ) -> Optional[str]:
     try:
+        try:
+            validate_url(file_url)
+        except SSRFError as e:
+            logger.warning("[FILE] SSRF blocked: %s — %s", file_url, e)
+            return None
         fetch_headers = {"User-Agent": "MatrixBridge/1.0"}
         async with aiohttp.ClientSession() as session:
             try:
@@ -409,6 +420,11 @@ async def fetch_and_send_video(
     logger: logging.Logger,
 ) -> Optional[str]:
     try:
+        try:
+            validate_url(video_url)
+        except SSRFError as e:
+            logger.warning("[VIDEO] SSRF blocked: %s — %s", video_url, e)
+            return None
         fetch_headers = {"User-Agent": "MatrixBridge/1.0"}
         async with aiohttp.ClientSession() as session:
             try:

--- a/src/utils/ssrf_protection.py
+++ b/src/utils/ssrf_protection.py
@@ -1,0 +1,84 @@
+import ipaddress
+import logging
+import socket
+from urllib.parse import urlparse
+
+logger = logging.getLogger(__name__)
+
+_BLOCKED_HOSTNAMES = frozenset({
+    "metadata.google.internal",
+    "metadata.goog",
+})
+
+
+class SSRFError(ValueError):
+    pass
+
+
+def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
+def validate_url(url: str) -> str:
+    """Validate a URL is safe for outbound requests (not targeting internal networks).
+
+    Resolves the hostname via DNS, then checks all returned IPs against
+    RFC 1918 / RFC 3927 / loopback / link-local / reserved / multicast ranges.
+
+    Args:
+        url: The URL to validate.
+
+    Returns:
+        The validated URL (unchanged).
+
+    Raises:
+        SSRFError: If the URL targets a private/internal IP or a blocked hostname.
+    """
+    parsed = urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+
+    if scheme not in ("http", "https"):
+        raise SSRFError(f"Blocked scheme: {scheme!r} (only http/https allowed)")
+
+    hostname = parsed.hostname
+    if not hostname:
+        raise SSRFError(f"No hostname in URL: {url}")
+
+    if hostname.lower() in _BLOCKED_HOSTNAMES:
+        raise SSRFError(f"Blocked hostname: {hostname}")
+
+    try:
+        ip = ipaddress.ip_address(hostname)
+        if _is_blocked_ip(ip):
+            raise SSRFError(f"Blocked IP: {hostname} is a private/reserved address")
+        return url
+    except ValueError:
+        pass
+
+    try:
+        infos = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
+    except socket.gaierror as e:
+        raise SSRFError(f"DNS resolution failed for {hostname}: {e}") from e
+
+    if not infos:
+        raise SSRFError(f"No DNS results for {hostname}")
+
+    for info in infos:
+        ip_str = info[4][0]
+        try:
+            ip = ipaddress.ip_address(ip_str)
+        except ValueError:
+            continue
+        if _is_blocked_ip(ip):
+            raise SSRFError(
+                f"Blocked: {hostname} resolves to private/reserved IP {ip_str}"
+            )
+
+    return url

--- a/tests/unit/test_ssrf_protection.py
+++ b/tests/unit/test_ssrf_protection.py
@@ -1,0 +1,163 @@
+import pytest
+import socket
+from unittest.mock import patch, AsyncMock, Mock
+from src.utils.ssrf_protection import SSRFError, validate_url
+
+
+class TestSSRFProtectionDirect:
+    @patch('socket.getaddrinfo')
+    def test_allows_public_http_url(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))
+        ]
+        url = "http://example.com/image.png"
+        result = validate_url(url)
+        assert result == url
+
+    @patch('socket.getaddrinfo')
+    def test_allows_public_https_url(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.35', 443))
+        ]
+        url = "https://cdn.example.com/file.pdf"
+        result = validate_url(url)
+        assert result == url
+
+    def test_blocks_localhost(self):
+        with pytest.raises(SSRFError):
+            validate_url("http://localhost/secret")
+
+    def test_blocks_127_0_0_1(self):
+        with pytest.raises(SSRFError):
+            validate_url("http://127.0.0.1/admin")
+
+    def test_blocks_ipv6_loopback(self):
+        with pytest.raises(SSRFError):
+            validate_url("http://[::1]/admin")
+
+    def test_blocks_10_x(self):
+        with pytest.raises(SSRFError):
+            validate_url("http://10.0.0.1/internal")
+
+    def test_blocks_172_16_x(self):
+        with pytest.raises(SSRFError):
+            validate_url("http://172.16.0.1/internal")
+
+    def test_blocks_192_168_x(self):
+        with pytest.raises(SSRFError):
+            validate_url("http://192.168.1.1/router")
+
+    def test_blocks_169_254_metadata(self):
+        with pytest.raises(SSRFError):
+            validate_url("http://169.254.169.254/latest/meta-data")
+
+    def test_blocks_metadata_google_internal(self):
+        with pytest.raises(SSRFError):
+            validate_url("http://metadata.google.internal/computeMetadata")
+
+    def test_blocks_ftp_scheme(self):
+        with pytest.raises(SSRFError):
+            validate_url("ftp://example.com/file")
+
+    def test_blocks_file_scheme(self):
+        with pytest.raises(SSRFError):
+            validate_url("file:///etc/passwd")
+
+    def test_blocks_no_hostname(self):
+        with pytest.raises(SSRFError):
+            validate_url("http:///path")
+
+    def test_blocks_0_0_0_0(self):
+        with pytest.raises(SSRFError):
+            validate_url("http://0.0.0.0/")
+
+    @patch('socket.getaddrinfo')
+    def test_blocks_dns_rebinding(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('127.0.0.1', 80))
+        ]
+        with pytest.raises(SSRFError):
+            validate_url("http://evil.com/")
+
+    @patch('socket.getaddrinfo')
+    def test_allows_dns_resolving_to_public_ip(self, mock_getaddrinfo):
+        mock_getaddrinfo.return_value = [
+            (socket.AF_INET, socket.SOCK_STREAM, 6, '', ('93.184.216.34', 80))
+        ]
+        url = "http://example.com/"
+        result = validate_url(url)
+        assert result == url
+
+    @patch('socket.getaddrinfo')
+    def test_blocks_dns_failure(self, mock_getaddrinfo):
+        mock_getaddrinfo.side_effect = socket.gaierror("Name resolution failed")
+        with pytest.raises(SSRFError):
+            validate_url("http://invalid-domain-that-does-not-exist.test/")
+
+
+class TestAgentMediaIntegration:
+    @pytest.mark.asyncio
+    async def test_fetch_and_send_image_blocks_ssrf(self):
+        from src.matrix.agent_media import fetch_and_send_image
+        
+        mock_config = Mock()
+        mock_config.homeserver_url = "http://test-synapse:8008"
+        mock_logger = Mock()
+        
+        with patch('src.matrix.agent_media.validate_url') as mock_validate:
+            mock_validate.side_effect = SSRFError("Blocked IP: 10.0.0.1")
+            
+            result = await fetch_and_send_image(
+                room_id="!test:matrix.test",
+                image_url="http://10.0.0.1/secret.png",
+                alt="test",
+                config=mock_config,
+                logger=mock_logger
+            )
+            
+            assert result is None
+            mock_logger.warning.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_fetch_and_send_file_blocks_ssrf(self):
+        from src.matrix.agent_media import fetch_and_send_file
+        
+        mock_config = Mock()
+        mock_config.homeserver_url = "http://test-synapse:8008"
+        mock_logger = Mock()
+        
+        with patch('src.matrix.agent_media.validate_url') as mock_validate:
+            mock_validate.side_effect = SSRFError("Blocked IP: 10.0.0.1")
+            
+            result = await fetch_and_send_file(
+                room_id="!test:matrix.test",
+                file_url="http://10.0.0.1/secret.pdf",
+                filename="secret.pdf",
+                config=mock_config,
+                logger=mock_logger
+            )
+            
+            assert result is None
+            mock_logger.warning.assert_called()
+
+    @pytest.mark.asyncio
+    async def test_fetch_and_send_video_blocks_ssrf(self):
+        from src.matrix.agent_media import fetch_and_send_video
+        
+        mock_config = Mock()
+        mock_config.homeserver_url = "http://test-synapse:8008"
+        mock_logger = Mock()
+        
+        with patch('src.matrix.agent_media.validate_url') as mock_validate:
+            mock_validate.side_effect = SSRFError("Blocked IP: 10.0.0.1")
+            
+            result = await fetch_and_send_video(
+                room_id="!test:matrix.test",
+                video_url="http://10.0.0.1/secret.mp4",
+                alt="test",
+                config=mock_config,
+                logger=mock_logger
+            )
+            
+            assert result is None
+            mock_logger.warning.assert_called()


### PR DESCRIPTION
## Summary

- Add DNS-level SSRF protection module (`src/utils/ssrf_protection.py`) that validates outbound URLs by resolving hostnames and checking IPs against RFC 1918, loopback, link-local, reserved, multicast, and unspecified ranges
- Guard all 3 user-controlled URL fetch points in `agent_media.py` (`fetch_and_send_image`, `fetch_and_send_file`, `fetch_and_send_video`) with `validate_url()` before any outbound request

## What's Protected

| Vector | File | Risk | Fix |
|--------|------|------|-----|
| `image_url` from agent response | `agent_media.py:117` | HIGH — user/agent-controlled | `validate_url()` guard |
| `file_url` from agent response | `agent_media.py:308` | HIGH — user/agent-controlled | `validate_url()` guard |
| `video_url` from agent response | `agent_media.py:424` | HIGH — user/agent-controlled | `validate_url()` guard |

### Not in scope (safe by design)
- `mxc://` downloads — these always go to our own homeserver endpoint, server_name is just a path segment
- All other HTTP calls — use `homeserver_url` / `letta_api_url` from environment config

## SSRF Protection Details

`validate_url()` performs:
1. **Scheme validation** — only `http`/`https` allowed
2. **Blocked hostname check** — `metadata.google.internal`, `metadata.goog`
3. **Direct IP check** — if hostname is an IP literal, checks against all blocked ranges
4. **DNS resolution** — resolves hostname via `socket.getaddrinfo`, checks all returned IPs
5. **Blocked IP ranges** — `is_private`, `is_loopback`, `is_link_local`, `is_reserved`, `is_multicast`, `is_unspecified`

This catches DNS rebinding attacks where `evil.com` resolves to `127.0.0.1`.

## Tests

20 new tests in `tests/unit/test_ssrf_protection.py`:
- 17 direct validation tests (public URLs, all blocked IP ranges, schemes, DNS rebinding, DNS failure)
- 3 integration tests (each agent_media function returns None on SSRF)

Full suite: **1012 passed**, 15 skipped, 0 failed

## Bead

Closes bd-lu93 (MXSYN-438, MXSYN-447)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Security Improvements

* **New Features**
  * Added Server-Side Request Forgery (SSRF) protection to validate and block outbound requests to private networks, loopback addresses, and restricted hosts
  * SSRF validation now applied to media handling to prevent access to restricted network resources

* **Tests**
  * Added comprehensive tests for SSRF protection and media handling integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->