### PR TITLE
Fix broken offset pagination in listAgents — use cursor-based only (bd-nped)

### DIFF
--- a/mcp-servers/matrix-identity-bridge/src/letta/letta-service.ts
+++ b/mcp-servers/matrix-identity-bridge/src/letta/letta-service.ts
@@ -76,7 +76,6 @@ export class LettaService {
    */
   async listAgents(pagination?: {
     limit?: number;
-    offset?: number;
     after?: string;
     before?: string;
   }): Promise<LettaAgentInfo[]> {
@@ -103,12 +102,6 @@ export class LettaService {
       }
       
       this.lastIndexRefresh = Date.now();
-
-      const offset = pagination?.offset ?? 0;
-      if (offset > 0 || pagination?.limit !== undefined) {
-        const end = pagination?.limit !== undefined ? offset + pagination.limit : undefined;
-        return agents.slice(offset, end);
-      }
 
       return agents;
     } catch (error) {

--- a/mcp-servers/matrix-identity-bridge/src/operations/letta.ts
+++ b/mcp-servers/matrix-identity-bridge/src/operations/letta.ts
@@ -84,13 +84,9 @@ export const letta_list: OperationHandler = async (args, ctx) => {
     throw new McpError(ErrorCode.InvalidParams, 'Invalid limit: must be a positive integer');
   }
 
-  if (args.offset !== undefined && (!Number.isInteger(args.offset) || args.offset < 0)) {
-    throw new McpError(ErrorCode.InvalidParams, 'Invalid offset: must be a non-negative integer');
-  }
 
   const agents = await letta.listAgents({
-    limit: args.limit,
-    offset: args.offset
+    limit: args.limit
   });
 
   const agentsWithIdentities = await Promise.all(

--- a/mcp-servers/matrix-identity-bridge/src/tools/MatrixMessaging.ts
+++ b/mcp-servers/matrix-identity-bridge/src/tools/MatrixMessaging.ts
@@ -1028,11 +1028,8 @@ const executeOperation = async (input: Input, ctx: ToolContext, callerContext: C
         if (input.limit !== undefined && (!Number.isInteger(input.limit) || input.limit < 1)) {
           throw new Error('Invalid limit: must be a positive integer for letta_list. Example: {operation: "letta_list", limit: 50}');
         }
-        if (input.offset !== undefined && (!Number.isInteger(input.offset) || input.offset < 0)) {
-          throw new Error('Invalid offset: must be a non-negative integer for letta_list. Example: {operation: "letta_list", offset: 50, limit: 50}');
-        }
 
-        const agents = await letta.listAgents({ limit: input.limit, offset: input.offset });
+        const agents = await letta.listAgents({ limit: input.limit });
         const agentsWithIdentities = await Promise.all(
           agents.map(async agent => {
             const identityId = IdentityManager.generateLettaId(agent.id);


### PR DESCRIPTION
## Summary

- Remove broken `offset` parameter from `listAgents()` that caused empty results when combined with `limit`
- Remove client-side `slice()` logic that silently discarded results
- Letta API uses cursor-based pagination (`after`/`before`/`limit`) which was already correctly wired

## Problem

`listAgents({limit: 5, offset: 10})` would:
1. Fetch only 5 agents from Letta API (respecting `limit`)
2. Apply `agents.slice(10, 15)` on those 5 results → **empty array**

## Fix

Remove `offset` from `listAgents` signature and all callers (`MatrixMessaging.ts`, `operations/letta.ts`). The cursor-based `after`/`before` params already work correctly for pagination.

## Files Changed

- `mcp-servers/matrix-identity-bridge/src/letta/letta-service.ts` — Remove `offset` from type, remove `slice()` logic
- `mcp-servers/matrix-identity-bridge/src/tools/MatrixMessaging.ts` — Remove `offset` validation and usage
- `mcp-servers/matrix-identity-bridge/src/operations/letta.ts` — Remove `offset` validation and usage

## Bead

Closes bd-nped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Removed offset-based pagination support. The offset parameter is no longer available for list operations. Pagination now relies exclusively on limit, after, and before parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->