### PR TITLE
feat: queue incoming messages when agent is busy instead of dropping

### DIFF
--- a/src/matrix/task_manager.py
+++ b/src/matrix/task_manager.py
@@ -1,11 +1,17 @@
 """
 Background Letta task management — dispatch, cancel, and track async tasks.
+
+Includes a per-room message queue so incoming messages received while an
+agent is busy are not dropped but processed after the current task finishes.
 """
 
 import asyncio
+import collections
 import logging
+import os
 import time
-from typing import Dict, Optional, Tuple
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple
 
 import aiohttp
 
@@ -22,10 +28,34 @@ _active_letta_tasks: Dict[Tuple[str, str], asyncio.Task] = {}
 _still_processing_last_sent: Dict[str, float] = {}
 _STILL_PROCESSING_COOLDOWN = 60.0  # seconds between notices per room
 
+# ── Per-room message queue ────────────────────────────────────────────
+_MAX_QUEUE_SIZE = int(os.getenv("LETTA_MESSAGE_QUEUE_MAX_SIZE", "5"))
+
+
+@dataclass
+class _QueuedMessage:
+    """Snapshot of everything needed to re-dispatch a queued message."""
+    room: Any
+    event: Any
+    config: Any
+    logger: Any
+    client: Any
+    room_agent_id: Optional[str]
+    gating_result: Any
+    message_text: str
+    user_reply_to_event_id: Optional[str]
+    auth_manager: Any = None
+
+
+# Per task_key → bounded deque of _QueuedMessage
+_pending_queues: Dict[Tuple[str, str], collections.deque] = {}
+
 
 def _on_letta_task_done(key: Tuple[str, str], task: asyncio.Task) -> None:
     _active_letta_tasks.pop(key, None)
     if task.cancelled():
+        # Clear queue on cancellation (e.g. /stop)
+        _pending_queues.pop(key, None)
         return
     exc = task.exception()
     if exc:
@@ -42,11 +72,58 @@ def _on_letta_task_done(key: Tuple[str, str], task: asyncio.Task) -> None:
                 f'[BG-TASK] Failed to enqueue alert for {key}: {alert_error}'
             )
 
+    # Drain the next queued message for this key, if any
+    _drain_next_queued_message(key)
+
+
+def _drain_next_queued_message(key: Tuple[str, str]) -> None:
+    """Pop the next queued message and dispatch it as a new background task."""
+    queue = _pending_queues.get(key)
+    if not queue:
+        _pending_queues.pop(key, None)
+        return
+    msg = queue.popleft()
+    if not queue:
+        _pending_queues.pop(key, None)
+
+    logger.info(
+        f'[BG-TASK] Draining queued message for {key} '
+        f'({len(queue) if queue else 0} remaining)'
+    )
+
+    try:
+        loop = asyncio.get_event_loop()
+    except RuntimeError:
+        logger.warning(f'[BG-TASK] No event loop to drain queue for {key}')
+        return
+
+    loop.create_task(_dispatch_queued_message(key, msg))
+
+
+async def _dispatch_queued_message(key: Tuple[str, str], msg: _QueuedMessage) -> None:
+    """Re-dispatch a previously queued message through the normal path."""
+    try:
+        await _dispatch_letta_task(
+            room=msg.room,
+            event=msg.event,
+            config=msg.config,
+            logger=msg.logger,
+            client=msg.client,
+            room_agent_id=msg.room_agent_id,
+            gating_result=msg.gating_result,
+            message_text=msg.message_text,
+            user_reply_to_event_id=msg.user_reply_to_event_id,
+            auth_manager=msg.auth_manager,
+        )
+    except Exception as exc:
+        logger.error(f'[BG-TASK] Failed to dispatch queued message for {key}: {exc}', exc_info=exc)
+
 
 async def cancel_all_letta_tasks() -> None:
     if not _active_letta_tasks:
         return
     logger.info(f'[BG-TASK] Cancelling {len(_active_letta_tasks)} active Letta tasks...')
+    _pending_queues.clear()
     for task in _active_letta_tasks.values():
         task.cancel()
     await asyncio.gather(*_active_letta_tasks.values(), return_exceptions=True)
@@ -59,11 +136,19 @@ async def _handle_stop_command(
     if message_text.strip().lower() != '/stop':
         return False
 
-    existing = _active_letta_tasks.get((room.room_id, room_agent_id or 'unknown'))
+    stop_key = (room.room_id, room_agent_id or 'unknown')
+    existing = _active_letta_tasks.get(stop_key)
     stopped = False
+
+    # Clear queued messages for this room
+    queue_cleared = len(_pending_queues.get(stop_key, []))
+    _pending_queues.pop(stop_key, None)
+    if queue_cleared:
+        logger.info(f'[STOP] Cleared {queue_cleared} queued message(s) for {stop_key}')
+
     if existing and not existing.done():
         existing.cancel()
-        _active_letta_tasks.pop((room.room_id, room_agent_id or 'unknown'), None)
+        _active_letta_tasks.pop(stop_key, None)
         stopped = True
         logger.info(f'[STOP] Cancelled active task for {room_agent_name} in {room.room_id}')
 
@@ -84,7 +169,14 @@ async def _handle_stop_command(
         except (LettaApiError, MatrixClientError, asyncio.TimeoutError, aiohttp.ClientError) as e:
             logger.warning(f'[STOP] Gateway abort failed: {e}')
 
-    msg = '⏹ Stopped.' if stopped else 'Nothing running to stop.'
+    if stopped and queue_cleared:
+        msg = f'⏹ Stopped. Cleared {queue_cleared} queued message(s).'
+    elif stopped:
+        msg = '⏹ Stopped.'
+    elif queue_cleared:
+        msg = f'⏹ Cleared {queue_cleared} queued message(s).'
+    else:
+        msg = 'Nothing running to stop.'
     await send_as_agent(room.room_id, msg, config, logger)
     return True
 
@@ -122,16 +214,14 @@ async def _dispatch_letta_task(
 
     existing_task = _active_letta_tasks.get(task_key)
     if existing_task and not existing_task.done():
-        now = time.monotonic()
-        last_sent = _still_processing_last_sent.get(room.room_id, 0.0)
-        if now - last_sent >= _STILL_PROCESSING_COOLDOWN:
-            logger.warning(
-                f'[BG-TASK] Agent still processing previous message for {task_key}, sending notice'
-            )
+        # ── Enqueue instead of dropping ────────────────────────────
+        queue = _pending_queues.get(task_key)
+        if queue is not None and len(queue) >= _MAX_QUEUE_SIZE:
+            logger.warning(f'[BG-TASK] Queue full ({_MAX_QUEUE_SIZE}) for {task_key}, dropping message')
             try:
                 await send_as_agent(
                     room.room_id,
-                    '⏳ Still processing previous message...',
+                    f'⏳ Queue full ({_MAX_QUEUE_SIZE} messages) — please wait for current task to finish.',
                     config,
                     logger,
                     msgtype='m.notice',
@@ -141,15 +231,46 @@ async def _dispatch_letta_task(
                     thread_event_id=thread_event_id,
                     thread_latest_event_id=thread_latest_event_id,
                 )
-                _still_processing_last_sent[room.room_id] = now
-            except (RuntimeError, ValueError, TypeError, asyncio.TimeoutError) as notice_error:
-                logger.debug(
-                    f'[BG-TASK] Failed to send still-processing notice for {task_key}: {notice_error}'
-                )
-        else:
+            except (RuntimeError, ValueError, TypeError, asyncio.TimeoutError):
+                pass
+            return True
+
+        if queue is None:
+            queue = collections.deque(maxlen=_MAX_QUEUE_SIZE)
+            _pending_queues[task_key] = queue
+
+        queued_msg = _QueuedMessage(
+            room=room,
+            event=event,
+            config=config,
+            logger=logger,
+            client=client,
+            room_agent_id=room_agent_id,
+            gating_result=gating_result,
+            message_text=message_text,
+            user_reply_to_event_id=user_reply_to_event_id,
+            auth_manager=auth_manager,
+        )
+        queue.append(queued_msg)
+        position = len(queue)
+        logger.info(f'[BG-TASK] Queued message for {task_key} (position {position}/{_MAX_QUEUE_SIZE})')
+
+        try:
+            await send_as_agent(
+                room.room_id,
+                f'⏳ Queued (position {position}) — will process after current task.',
+                config,
+                logger,
+                msgtype='m.notice',
+                reply_to_event_id=(
+                    None if thread_event_id else (reply_event_id_for_notice or user_reply_to_event_id)
+                ),
+                thread_event_id=thread_event_id,
+                thread_latest_event_id=thread_latest_event_id,
+            )
+        except (RuntimeError, ValueError, TypeError, asyncio.TimeoutError) as notice_error:
             logger.debug(
-                f'[BG-TASK] Suppressed "still processing" notice for {task_key} '
-                f'(cooldown: {_STILL_PROCESSING_COOLDOWN - (now - last_sent):.0f}s remaining)'
+                f'[BG-TASK] Failed to send queued notice for {task_key}: {notice_error}'
             )
         return True
 

--- a/tests/unit/test_task_manager_queue.py
+++ b/tests/unit/test_task_manager_queue.py
@@ -1,0 +1,308 @@
+"""Tests for per-room message queue when agent is busy (GitHub #28)."""
+
+import asyncio
+import collections
+from dataclasses import dataclass
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.matrix.task_manager import (
+    _active_letta_tasks,
+    _dispatch_letta_task,
+    _handle_stop_command,
+    _on_letta_task_done,
+    _pending_queues,
+    _QueuedMessage,
+    _MAX_QUEUE_SIZE,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeRoom:
+    room_id: str = "!room:test"
+    display_name: str = "Test Room"
+
+    def user_name(self, sender):
+        return sender
+
+
+@dataclass
+class _FakeEvent:
+    sender: str = "@user:test"
+    event_id: str = "$evt1"
+    source: dict = None
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    """Ensure module-level state is clean between tests."""
+    _active_letta_tasks.clear()
+    _pending_queues.clear()
+    yield
+    _active_letta_tasks.clear()
+    _pending_queues.clear()
+
+
+@pytest.fixture
+def mock_send():
+    with patch("src.matrix.task_manager.send_as_agent", new_callable=AsyncMock) as m:
+        yield m
+
+
+@pytest.fixture
+def mock_process():
+    with patch("src.matrix.task_manager.process_letta_message", new_callable=AsyncMock) as m:
+        yield m
+
+
+# ---------------------------------------------------------------------------
+# Tests: message queuing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_message_queued_when_busy(mock_send, mock_process):
+    """When an agent is busy, the incoming message should be queued."""
+    room = _FakeRoom()
+    config = MagicMock()
+    task_key = (room.room_id, "agent-1")
+
+    # Simulate an active task
+    active = asyncio.Future()
+    _active_letta_tasks[task_key] = asyncio.ensure_future(active)
+
+    result = await _dispatch_letta_task(
+        room=room,
+        event=_FakeEvent(),
+        config=config,
+        logger=MagicMock(),
+        client=MagicMock(),
+        room_agent_id="agent-1",
+        gating_result=None,
+        message_text="hello",
+        user_reply_to_event_id=None,
+    )
+
+    assert result is True
+    assert task_key in _pending_queues
+    assert len(_pending_queues[task_key]) == 1
+    assert _pending_queues[task_key][0].message_text == "hello"
+
+    # Notice should mention position
+    mock_send.assert_called_once()
+    notice_text = mock_send.call_args[0][1]
+    assert "Queued" in notice_text
+    assert "position 1" in notice_text
+
+    # Cleanup
+    active.cancel()
+    _active_letta_tasks[task_key].cancel()
+
+
+@pytest.mark.asyncio
+async def test_queue_respects_max_size(mock_send, mock_process):
+    """Queue should reject messages once full."""
+    room = _FakeRoom()
+    config = MagicMock()
+    task_key = (room.room_id, "agent-1")
+
+    active = asyncio.Future()
+    _active_letta_tasks[task_key] = asyncio.ensure_future(active)
+
+    # Fill the queue
+    _pending_queues[task_key] = collections.deque(
+        [_QueuedMessage(
+            room=room, event=_FakeEvent(), config=config,
+            logger=MagicMock(), client=MagicMock(),
+            room_agent_id="agent-1", gating_result=None,
+            message_text=f"msg-{i}", user_reply_to_event_id=None,
+        ) for i in range(_MAX_QUEUE_SIZE)],
+        maxlen=_MAX_QUEUE_SIZE,
+    )
+
+    result = await _dispatch_letta_task(
+        room=room,
+        event=_FakeEvent(),
+        config=config,
+        logger=MagicMock(),
+        client=MagicMock(),
+        room_agent_id="agent-1",
+        gating_result=None,
+        message_text="overflow",
+        user_reply_to_event_id=None,
+    )
+
+    assert result is True
+    # Should still have max size (overflow message dropped)
+    assert len(_pending_queues[task_key]) == _MAX_QUEUE_SIZE
+    # Notice should mention "Queue full"
+    notice_text = mock_send.call_args[0][1]
+    assert "Queue full" in notice_text
+
+    active.cancel()
+    _active_letta_tasks[task_key].cancel()
+
+
+@pytest.mark.asyncio
+async def test_queued_messages_processed_in_order(mock_send, mock_process):
+    """After task completion, queued messages should be drained in FIFO order."""
+    room = _FakeRoom()
+    config = MagicMock()
+    task_key = (room.room_id, "agent-1")
+
+    # Queue 2 messages
+    _pending_queues[task_key] = collections.deque([
+        _QueuedMessage(
+            room=room, event=_FakeEvent(), config=config,
+            logger=MagicMock(), client=MagicMock(),
+            room_agent_id="agent-1", gating_result=None,
+            message_text="first", user_reply_to_event_id=None,
+        ),
+        _QueuedMessage(
+            room=room, event=_FakeEvent(), config=config,
+            logger=MagicMock(), client=MagicMock(),
+            room_agent_id="agent-1", gating_result=None,
+            message_text="second", user_reply_to_event_id=None,
+        ),
+    ], maxlen=_MAX_QUEUE_SIZE)
+
+    # Simulate task completion
+    completed_task = asyncio.Future()
+    completed_task.set_result(None)
+
+    # Patch _dispatch_letta_task for the drain call to avoid full processing
+    with patch("src.matrix.task_manager._dispatch_letta_task", new_callable=AsyncMock) as mock_dispatch:
+        _on_letta_task_done(task_key, completed_task)
+        # Give the loop a tick to schedule the drain task
+        await asyncio.sleep(0.05)
+
+    # First message should be dispatched
+    assert mock_dispatch.called
+    first_call_text = mock_dispatch.call_args[1]["message_text"]
+    assert first_call_text == "first"
+
+
+@pytest.mark.asyncio
+async def test_queue_is_per_room(mock_send, mock_process):
+    """Different rooms should have independent queues."""
+    config = MagicMock()
+    key_a = ("!roomA:test", "agent-1")
+    key_b = ("!roomB:test", "agent-1")
+
+    active_a = asyncio.Future()
+    active_b = asyncio.Future()
+    _active_letta_tasks[key_a] = asyncio.ensure_future(active_a)
+    _active_letta_tasks[key_b] = asyncio.ensure_future(active_b)
+
+    await _dispatch_letta_task(
+        room=_FakeRoom(room_id="!roomA:test"),
+        event=_FakeEvent(), config=config,
+        logger=MagicMock(), client=MagicMock(),
+        room_agent_id="agent-1", gating_result=None,
+        message_text="for room A", user_reply_to_event_id=None,
+    )
+
+    await _dispatch_letta_task(
+        room=_FakeRoom(room_id="!roomB:test"),
+        event=_FakeEvent(), config=config,
+        logger=MagicMock(), client=MagicMock(),
+        room_agent_id="agent-1", gating_result=None,
+        message_text="for room B", user_reply_to_event_id=None,
+    )
+
+    assert len(_pending_queues[key_a]) == 1
+    assert len(_pending_queues[key_b]) == 1
+    assert _pending_queues[key_a][0].message_text == "for room A"
+    assert _pending_queues[key_b][0].message_text == "for room B"
+
+    active_a.cancel()
+    active_b.cancel()
+    _active_letta_tasks[key_a].cancel()
+    _active_letta_tasks[key_b].cancel()
+
+
+@pytest.mark.asyncio
+async def test_stop_clears_queue(mock_send):
+    """The /stop command should clear the queue for the room."""
+    room = _FakeRoom()
+    config = MagicMock()
+    config.letta_gateway_url = None
+    task_key = (room.room_id, "agent-1")
+
+    # Active task + queued messages
+    active = asyncio.Future()
+    _active_letta_tasks[task_key] = asyncio.ensure_future(active)
+    _pending_queues[task_key] = collections.deque([
+        _QueuedMessage(
+            room=room, event=_FakeEvent(), config=config,
+            logger=MagicMock(), client=MagicMock(),
+            room_agent_id="agent-1", gating_result=None,
+            message_text="queued msg", user_reply_to_event_id=None,
+        ),
+    ], maxlen=_MAX_QUEUE_SIZE)
+
+    result = await _handle_stop_command(
+        room=room,
+        config=config,
+        logger=MagicMock(),
+        room_agent_id="agent-1",
+        room_agent_name="TestAgent",
+        message_text="/stop",
+    )
+
+    assert result is True
+    # Queue should be cleared
+    assert task_key not in _pending_queues
+    # Stop message should mention the cleared queue
+    stop_msg = mock_send.call_args[0][1]
+    assert "Stopped" in stop_msg
+    assert "1 queued" in stop_msg
+
+    active.cancel()
+
+
+@pytest.mark.asyncio
+async def test_task_cancellation_clears_queue():
+    """When a task is cancelled, its queue should be cleared too."""
+    task_key = ("!room:test", "agent-1")
+    _pending_queues[task_key] = collections.deque([MagicMock()], maxlen=_MAX_QUEUE_SIZE)
+
+    cancelled_task = asyncio.Future()
+    cancelled_task.cancel()
+
+    try:
+        _on_letta_task_done(task_key, cancelled_task)
+    except asyncio.CancelledError:
+        pass
+
+    assert task_key not in _pending_queues
+
+
+@pytest.mark.asyncio
+async def test_no_queue_when_not_busy(mock_send, mock_process):
+    """When no active task exists, message should dispatch normally (no queue)."""
+    room = _FakeRoom()
+    config = MagicMock()
+
+    result = await _dispatch_letta_task(
+        room=room,
+        event=_FakeEvent(),
+        config=config,
+        logger=MagicMock(),
+        client=MagicMock(),
+        room_agent_id="agent-1",
+        gating_result=None,
+        message_text="hello",
+        user_reply_to_event_id=None,
+    )
+
+    assert result is True
+    # No queue should be created
+    assert not _pending_queues
+    # process_letta_message should be called (via asyncio.create_task)
+    mock_send.assert_not_called()  # No notice sent


### PR DESCRIPTION
## Summary
- Messages sent while an agent is processing are now **queued** (not dropped) in a per-room bounded FIFO
- Queue auto-drains after the current task completes, processing messages in order
- Default max queue size: 5 (configurable via `LETTA_MESSAGE_QUEUE_MAX_SIZE`)
- `/stop` clears the active task **and** all queued messages
- User sees `⏳ Queued (position N) — will process after current task.` instead of the old "Still processing..." notice
- When queue is full: `⏳ Queue full (5 messages) — please wait`

## Test plan
- [x] 7 new unit tests: queuing, max size, FIFO order, per-room isolation, /stop, cancellation, normal dispatch
- [ ] CI passes (unit tests, lint, docker build)
- [ ] Manual: send multiple messages while agent is processing, verify they're queued and processed in order
- [ ] Manual: verify `/stop` clears queue and mentions cleared count

Closes #28

🤖 Generated with [Letta Code](https://letta.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Messages are now queued instead of dropped when the agent is busy processing a previous request.
  * Users receive a "queued" notification when their message is queued.
  * Queued messages are processed in FIFO order once the agent becomes available.
  * Queue is cleared when the `/stop` command is issued.
  * New messages are dropped only when the queue reaches capacity.

* **Tests**
  * Added comprehensive test coverage for message queueing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->